### PR TITLE
Fix percy label multitrigger qa

### DIFF
--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   copy_artifact:
     name: Copy changed files to GHA artifact
-    if: "contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')"
+    if: "(github.event.action == 'synchronize' && contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')) || (github.event.action == 'labeled' && github.event.label.name == 'Review: Percy needed')"
     uses: ./.github/workflows/percy-prepare.yml
     with:
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -1,5 +1,4 @@
 # This workflow ensures Percy is executed against PRs with the Percy required label, regardless of which paths were changed
-# Push to PR with percy label on it
 name: "Percy (labeled)"
 
 on:

--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -11,7 +11,21 @@ on:
       - synchronize
 
 jobs:
+  echo_action:
+    name: Echo action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo action
+        run: |
+          echo "Action: ${{ github.event.action }}"
+          if [ "${{ github.event.action }}" == "labeled" ]; then
+            echo "Label: ${{ github.event.label.name }}"
+          else
+            echo "Labels: ${{ toJson(github.event.pull_request.labels.*.name) }}"
+          fi
+
   copy_artifact:
+    needs: echo_action
     name: Copy changed files to GHA artifact
     if: "(github.event.action == 'synchronize' && contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')) || (github.event.action == 'labeled' && github.event.label.name == 'Review: Percy needed')"
     uses: ./.github/workflows/percy-prepare.yml

--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -1,4 +1,5 @@
 # This workflow ensures Percy is executed against PRs with the Percy required label, regardless of which paths were changed
+# Push to PR with percy label on it
 name: "Percy (labeled)"
 
 on:


### PR DESCRIPTION
QA for https://github.com/canonical/vanilla-framework/pull/5191

## How to read the QA Echo Output
Note that for this QA, I am using a version of the fix that has an additional job added to echo out the name of the GH action trigger, and the PR labels. View the "Echo action" job in the GHA output.

### Labeled
Example of a trigger-by-label, showing the label that was just applied (label is not Percy needed so the copy artifact job is skipped)
![image](https://github.com/jmuzina/vanilla-framework/assets/46915153/c80f1f67-487e-46ce-bc55-782b15026bca)

Trigger-by-label when the label is Percy needed; triggers the copy artifact job
![image](https://github.com/jmuzina/vanilla-framework/assets/46915153/5c1b9ee1-2360-4ba0-a609-a53a63ebd3df)

### Synchronized
Trigger-by-synchronize, showing all labels on the PR. This runs because the Percy label is found.
![image](https://github.com/jmuzina/vanilla-framework/assets/46915153/73f9065c-c3fc-4b5e-bc37-84a2a334ee66)

Trigger-by-synchronize that is skipped due to the Percy label not being found.
![image](https://github.com/jmuzina/vanilla-framework/assets/46915153/80618aee-b177-4ae7-987b-59bd3d3ec89f)


